### PR TITLE
copied ActionProfiles and ActionRegions from carapace-bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Carapace-aws is an enriched completer for [aws-cli].
 ## How it works
 
 The subcommands in [aws-cli] are mostly based on the [botocore] service definitions.
-These are `json` files that contain additional information and static completions.
+Which are `json` files that contain additional information and static completions.
 But these are not fully exposed to the shell completion and only accessible in [auto-prompt].
 
 Carapace-aws parses the [botocore] service definitions into a [carapace] based completer.
@@ -16,7 +16,7 @@ Undefined completions are simply delegated to the official [aws_completer].
 
 ## Getting Started
 
-When using [carapace-bin] this happens implicitly when the `carapace-aws` binary is in [PATH].
+When using [carapace-bin] `carapace-aws` is implicitly used when the binary is in [PATH].
 
 Otherwise the completions can be loaded directly with [`carapace-aws _carapace`](https://carapace-sh.github.io/carapace/carapace/gen.html#hidden-subcommand).
 

--- a/cmd/carapace-aws/cmd/root.go
+++ b/cmd/carapace-aws/cmd/root.go
@@ -6,6 +6,8 @@ import (
 	"github.com/carapace-sh/carapace"
 	"github.com/carapace-sh/carapace-aws/cmd/carapace-aws/cmd/botocore"
 	"github.com/carapace-sh/carapace-aws/cmd/carapace-aws/cmd/common"
+	_ "github.com/carapace-sh/carapace-aws/pkg/actions"
+	"github.com/carapace-sh/carapace-aws/pkg/actions/aws"
 	spec "github.com/carapace-sh/carapace-spec"
 	"github.com/carapace-sh/carapace/pkg/style"
 	"github.com/spf13/cobra"
@@ -49,8 +51,8 @@ func init() {
 		),
 		"color":   carapace.ActionValues("on", "off", "auto").StyleF(style.ForKeyword),
 		"output":  carapace.ActionValues("json", "text", "table", "yaml", "yaml-stream"),
-		"profile": spec.ActionMacro("$carapace.tools.aws.Profiles"),
-		"region":  spec.ActionMacro("$carapace.tools.aws.Regions"),
+		"profile": aws.ActionProfiles(),
+		"region":  aws.ActionRegions(),
 	})
 
 	for name, description := range botocore.Services() {
@@ -110,4 +112,6 @@ func init() {
 			common.ActionBridgeAwsCompleter(),
 		)
 	}
+
+	spec.Register(rootCmd)
 }

--- a/go.mod
+++ b/go.mod
@@ -7,10 +7,12 @@ require (
 	github.com/carapace-sh/carapace-spec v1.3.5
 	github.com/spf13/cobra v1.10.1
 	github.com/spf13/pflag v1.0.10
+	gopkg.in/ini.v1 v1.67.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
 	github.com/carapace-sh/carapace-shlex v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	github.com/stretchr/testify v1.11.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,12 @@ github.com/carapace-sh/carapace-shlex v1.1.1/go.mod h1:lJ4ZsdxytE0wHJ8Ta9S7Qq0Xp
 github.com/carapace-sh/carapace-spec v1.3.5 h1:F/OS1CQciwTtyZbaPsOz5jQwtzbjHUoPCjCClELbb+s=
 github.com/carapace-sh/carapace-spec v1.3.5/go.mod h1:sLWIRftQoRogZj8xdDYqnZb8K4N0/YbEj03m2C5R8ZA=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
 github.com/spf13/cobra v1.10.1 h1:lJeBwCfmrnXthfAupyUTzJ/J4Nc1RsHC/mSRU2dll/s=
@@ -15,7 +19,11 @@ github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
+gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/actions/actions.go
+++ b/pkg/actions/actions.go
@@ -1,0 +1,12 @@
+package actions
+
+import (
+	"github.com/carapace-sh/carapace-aws/pkg/actions/aws"
+	spec "github.com/carapace-sh/carapace-spec"
+)
+
+func init() {
+	// TODO create with go:generate
+	spec.AddMacro("Profiles", spec.MacroN(aws.ActionProfiles))
+	spec.AddMacro("Regions", spec.MacroN(aws.ActionRegions))
+}

--- a/pkg/actions/aws/aws.go
+++ b/pkg/actions/aws/aws.go
@@ -1,0 +1,86 @@
+// package aws contains amazon web services related actions
+package aws
+
+import (
+	"strings"
+
+	"github.com/carapace-sh/carapace"
+	"gopkg.in/ini.v1"
+)
+
+// ActionRegions completes region names
+//
+//	eu-south-1 (Europe Milan)
+//	ap-east-1 (Asia Pacific Hong Kong)
+func ActionRegions() carapace.Action {
+	return carapace.ActionValuesDescribed(
+		"af-south-1", "Africa (Cape Town)",
+		"ap-east-1", "Asia Pacific (Hong Kong)",
+		"ap-east-2", "Asia Pacific (Taipei)",
+		"ap-northeast-1", "Asia Pacific (Tokyo)",
+		"ap-northeast-2", "Asia Pacific (Seoul)",
+		"ap-northeast-3", "Asia Pacific (Osaka)",
+		"ap-south-1", "Asia Pacific (Mumbai)",
+		"ap-south-2", "Asia Pacific (Hyderabad)",
+		"ap-southeast-1", "Asia Pacific (Singapore)",
+		"ap-southeast-2", "Asia Pacific (Sydney)",
+		"ap-southeast-3", "Asia Pacific (Jakarta)",
+		"ap-southeast-4", "Asia Pacific (Melbourne)",
+		"ap-southeast-5", "Asia Pacific (Malaysia)",
+		"ap-southeast-6", "Asia Pacific (New Zealand)",
+		"ap-southeast-7", "Asia Pacific (Thailand)",
+		"ca-central-1", "Canada (Central)",
+		"ca-west-1", "Canada West (Calgary)",
+		"eu-central-1", "Europe (Frankfurt)",
+		"eu-central-2", "Europe (Zurich)",
+		"eu-north-1", "Europe (Stockholm)",
+		"eu-south-1", "Europe (Milan)",
+		"eu-south-2", "Europe (Spain)",
+		"eu-west-1", "Europe (Ireland)",
+		"eu-west-2", "Europe (London)",
+		"eu-west-3", "Europe (Paris)",
+		"il-central-1", "Israel (Tel Aviv)",
+		"me-central-1", "Middle East (UAE)",
+		"me-south-1", "Middle East (Bahrain)",
+		"mx-central-1", "Mexico (Central)",
+		"sa-east-1", "South America (São Paulo)",
+		"us-east-1", "US East (N. Virginia)",
+		"us-east-2", "US East (Ohio)",
+		"us-west-1", "US West (N. California)",
+		"us-west-2", "US West (Oregon)",
+	)
+}
+
+// ActionProfiles completes configuration profile names
+//
+//	someprofile (eu-central-1)
+//	anotherprofile (us-east-1)
+func ActionProfiles() carapace.Action {
+	return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+		profiles := []string{}
+
+		// TODO support windows
+		if path, err := c.Abs("~/.aws/config"); err != nil {
+			return carapace.ActionMessage(err.Error())
+		} else {
+			if cfg, err := ini.Load(path); err != nil {
+				return carapace.ActionMessage(err.Error())
+			} else {
+				for _, section := range cfg.Sections() {
+					if after, ok := strings.CutPrefix(section.Name(), "profile "); ok {
+						profiles = append(profiles, after)
+						if key, err := section.GetKey("region"); err != nil {
+							profiles = append(profiles, "")
+						} else {
+							profiles = append(profiles, key.String())
+						}
+					}
+				}
+				if len(profiles) == 0 {
+					profiles = append(profiles, "default", "")
+				}
+				return carapace.ActionValuesDescribed(profiles...)
+			}
+		}
+	})
+}


### PR DESCRIPTION
avoids the depency so that carapace-aws can be used standalone (at least for now)
