### PR TITLE
Compare wait subcommands in service tests

### DIFF
--- a/cmd/carapace-aws/main_test.go
+++ b/cmd/carapace-aws/main_test.go
@@ -79,33 +79,47 @@ func TestService(t *testing.T) {
 			for _, operation := range command.Commands {
 				t.Run(operation.Name, func(t *testing.T) {
 					t.Parallel()
-					patch := carapace.DiffPatch(
-						bridge.ActionAws("aws"),
-						carapace.Batch(
-							bridge.ActionCarapace("carapace-aws"),
-							// force positional completion for outfile if available (returned by aws completer for streaming operations)
-							bridge.ActionCarapace("carapace-aws").
-								Chdir(testDir).
-								Invoke(carapace.NewContext(service, operation.Name, "")).
-								Retain("outfile").ToA(),
-						).ToA(),
-						carapace.NewContext(service, operation.Name, "--"),
-					)
-
-					s := []string{fmt.Sprintf("\033[2m# %v %v\033[0m", service, operation.Name)}
-					for _, line := range patch {
-						switch {
-						case strings.HasPrefix(line, "-"):
-							s = append(s, fmt.Sprintf("\033[0;31m%v\033[0m", line))
-							t.Fail()
-						case strings.HasPrefix(line, "+"):
-							s = append(s, fmt.Sprintf("\033[0;32m%v\033[0m", line))
-							t.Fail()
-						}
-					}
-					fmt.Println(strings.Join(s, "\n")) // TODO locking needed?
+					compareCommand(t, testDir, service, operation.Name)
 				})
+
+				if operation.Name == "wait" {
+					for _, waitCommand := range operation.Commands {
+						t.Run(operation.Name+"/"+waitCommand.Name, func(t *testing.T) {
+							t.Parallel()
+							compareCommand(t, testDir, service, operation.Name, waitCommand.Name)
+						})
+					}
+				}
 			}
 		})
 	}
+}
+
+func compareCommand(t *testing.T, testDir string, service string, args ...string) {
+	contextArgs := append([]string{service}, args...)
+	patch := carapace.DiffPatch(
+		bridge.ActionAws("aws"),
+		carapace.Batch(
+			bridge.ActionCarapace("carapace-aws"),
+			// force positional completion for outfile if available (returned by aws completer for streaming operations)
+			bridge.ActionCarapace("carapace-aws").
+				Chdir(testDir).
+				Invoke(carapace.NewContext(append(contextArgs, "")...)).
+				Retain("outfile").ToA(),
+		).ToA(),
+		carapace.NewContext(append(contextArgs, "--")...),
+	)
+
+	s := []string{fmt.Sprintf("\033[2m# %v\033[0m", strings.Join(contextArgs, " "))}
+	for _, line := range patch {
+		switch {
+		case strings.HasPrefix(line, "-"):
+			s = append(s, fmt.Sprintf("\033[0;31m%v\033[0m", line))
+			t.Fail()
+		case strings.HasPrefix(line, "+"):
+			s = append(s, fmt.Sprintf("\033[0;32m%v\033[0m", line))
+			t.Fail()
+		}
+	}
+	fmt.Println(strings.Join(s, "\n")) // TODO locking needed?
 }


### PR DESCRIPTION
Refs #46

## Summary
- extend service comparison tests to include nested `wait` subcommands
- factor the operation comparison logic into a reusable helper
- preserve the existing outfile-retention path for streaming operation checks

## Validation
- `go test ./cmd/carapace-aws/...`
- `go test ./...`
- `git diff --check`
