### PR TITLE
expose aws action macros

### DIFF
--- a/pkg/actions/actions.go
+++ b/pkg/actions/actions.go
@@ -5,8 +5,24 @@ import (
 	spec "github.com/carapace-sh/carapace-spec"
 )
 
+// Macros exposes carapace-aws actions for reuse by other commands and specs.
+var Macros = spec.MacroMap{
+	"Profiles": {
+		Name:        "Profiles",
+		Description: "Complete AWS profile names from the local AWS config.",
+		Function:    "github.com/carapace-sh/carapace-aws/pkg/actions/aws#ActionProfiles",
+		Macro:       spec.MacroN(aws.ActionProfiles).Macro,
+	},
+	"Regions": {
+		Name:        "Regions",
+		Description: "Complete AWS region names.",
+		Function:    "github.com/carapace-sh/carapace-aws/pkg/actions/aws#ActionRegions",
+		Macro:       spec.MacroN(aws.ActionRegions).Macro,
+	},
+}
+
 func init() {
-	// TODO create with go:generate
-	spec.AddMacro("Profiles", spec.MacroN(aws.ActionProfiles))
-	spec.AddMacro("Regions", spec.MacroN(aws.ActionRegions))
+	for name, macro := range Macros {
+		spec.AddMacro(name, macro)
+	}
 }

--- a/pkg/actions/actions_test.go
+++ b/pkg/actions/actions_test.go
@@ -1,0 +1,18 @@
+package actions
+
+import "testing"
+
+func TestMacrosExposed(t *testing.T) {
+	for _, name := range []string{"Profiles", "Regions"} {
+		macro, ok := Macros[name]
+		if !ok {
+			t.Fatalf("expected macro %q to be exposed", name)
+		}
+		if macro.Name != name {
+			t.Fatalf("expected macro %q to use matching name, got %q", name, macro.Name)
+		}
+		if macro.Function == "" {
+			t.Fatalf("expected macro %q to expose its source function", name)
+		}
+	}
+}


### PR DESCRIPTION
Closes #105.

This exposes the existing carapace-aws macros as a public `actions.Macros` map so other commands and specs can import/reuse them directly, while preserving the existing `_carapace macro` registration by registering the same map during package init.

Validation:
- `go test ./pkg/actions ./pkg/actions/aws`
- `go test ./cmd/carapace-aws/cmd/... ./cmd/carapace-spec-botocore/... ./pkg/...`
- `go run ./cmd/carapace-aws _carapace macro` lists `Profiles` and `Regions`
- `go run ./cmd/carapace-aws _carapace macro Regions`
- `git diff --check`

Note: `go test ./...` was attempted on Windows but timed out after 5 minutes; the repo's top-level AWS integration comparison depends on the external `aws_completer`, which is not installed in this environment.