### PR TITLE
Complete aws wait subcommand completions

### DIFF
--- a/cmd/carapace-aws/cmd/root.go
+++ b/cmd/carapace-aws/cmd/root.go
@@ -22,6 +22,33 @@ var rootCmd = &cobra.Command{
 func Execute() error {
 	return rootCmd.Execute()
 }
+
+func addAwsCompleterFallbacks(cmd *cobra.Command, command spec.Command) {
+	carapace.Gen(cmd).PreInvoke(func(cmd *cobra.Command, flag *pflag.Flag, action carapace.Action) carapace.Action {
+		if flag != nil && flag.Value.Type() != "bool" {
+			if _, ok := command.Completion.Flag[flag.Name]; !ok {
+				return common.ActionBridgeAwsCompleter()
+			}
+		}
+		return action
+	})
+
+	for _, subCommand := range command.Commands {
+		if subCmd := findSubcommand(cmd, subCommand.Name); subCmd != nil {
+			addAwsCompleterFallbacks(subCmd, spec.Command(subCommand))
+		}
+	}
+}
+
+func findSubcommand(cmd *cobra.Command, name string) *cobra.Command {
+	for _, subCmd := range cmd.Commands() {
+		if subCmd.Name() == name {
+			return subCmd
+		}
+	}
+	return nil
+}
+
 func init() {
 	rootCmd.SetUsageFunc(func(c *cobra.Command) error { return nil })
 	carapace.Gen(rootCmd).Standalone()
@@ -72,17 +99,8 @@ func init() {
 
 			for _, subCmd := range botoCommand.Commands {
 				operationCmd := spec.Command(subCmd).ToCobra()
+				addAwsCompleterFallbacks(operationCmd, spec.Command(subCmd))
 				serviceCmd.AddCommand(operationCmd)
-
-				carapace.Gen(operationCmd).PreInvoke(func(cmd *cobra.Command, flag *pflag.Flag, action carapace.Action) carapace.Action {
-					// TODO same for deeper wait subcommands
-					if flag != nil && flag.Value.Type() != "bool" {
-						if _, ok := subCmd.Completion.Flag[flag.Name]; !ok {
-							return common.ActionBridgeAwsCompleter()
-						}
-					}
-					return action
-				})
 			}
 		})
 	}

--- a/cmd/carapace-aws/main_test.go
+++ b/cmd/carapace-aws/main_test.go
@@ -1,4 +1,4 @@
-//#go:build integration
+//go:build integration
 
 package main
 
@@ -12,6 +12,7 @@ import (
 	"github.com/carapace-sh/carapace"
 	"github.com/carapace-sh/carapace-aws/cmd/carapace-aws/cmd/botocore"
 	"github.com/carapace-sh/carapace-bridge/pkg/actions/bridge"
+	"github.com/carapace-sh/carapace-spec/pkg/command"
 )
 
 func TestService(t *testing.T) {
@@ -77,35 +78,50 @@ func TestService(t *testing.T) {
 				t.Fatal(err.Error())
 			}
 			for _, operation := range command.Commands {
-				t.Run(operation.Name, func(t *testing.T) {
-					t.Parallel()
-					patch := carapace.DiffPatch(
-						bridge.ActionAws("aws"),
-						carapace.Batch(
-							bridge.ActionCarapace("carapace-aws"),
-							// force positional completion for outfile if available (returned by aws completer for streaming operations)
-							bridge.ActionCarapace("carapace-aws").
-								Chdir(testDir).
-								Invoke(carapace.NewContext(service, operation.Name, "")).
-								Retain("outfile").ToA(),
-						).ToA(),
-						carapace.NewContext(service, operation.Name, "--"),
-					)
-
-					s := []string{fmt.Sprintf("\033[2m# %v %v\033[0m", service, operation.Name)}
-					for _, line := range patch {
-						switch {
-						case strings.HasPrefix(line, "-"):
-							s = append(s, fmt.Sprintf("\033[0;31m%v\033[0m", line))
-							t.Fail()
-						case strings.HasPrefix(line, "+"):
-							s = append(s, fmt.Sprintf("\033[0;32m%v\033[0m", line))
-							t.Fail()
-						}
-					}
-					fmt.Println(strings.Join(s, "\n")) // TODO locking needed?
-				})
+				testCommand(t, testDir, service, nil, operation)
 			}
 		})
+	}
+}
+
+func testCommand(t *testing.T, testDir string, service string, parentPath []string, operation command.Command) {
+	commandPath := append(append([]string{}, parentPath...), operation.Name)
+
+	t.Run(strings.Join(commandPath, "/"), func(t *testing.T) {
+		t.Parallel()
+
+		baseContext := append([]string{service}, commandPath...)
+		positionalContext := append(append([]string{}, baseContext...), "")
+		flagContext := append(append([]string{}, baseContext...), "--")
+
+		patch := carapace.DiffPatch(
+			bridge.ActionAws("aws"),
+			carapace.Batch(
+				bridge.ActionCarapace("carapace-aws"),
+				// force positional completion for outfile if available (returned by aws completer for streaming operations)
+				bridge.ActionCarapace("carapace-aws").
+					Chdir(testDir).
+					Invoke(carapace.NewContext(positionalContext...)).
+					Retain("outfile").ToA(),
+			).ToA(),
+			carapace.NewContext(flagContext...),
+		)
+
+		s := []string{fmt.Sprintf("\033[2m# %v %v\033[0m", service, strings.Join(commandPath, " "))}
+		for _, line := range patch {
+			switch {
+			case strings.HasPrefix(line, "-"):
+				s = append(s, fmt.Sprintf("\033[0;31m%v\033[0m", line))
+				t.Fail()
+			case strings.HasPrefix(line, "+"):
+				s = append(s, fmt.Sprintf("\033[0;32m%v\033[0m", line))
+				t.Fail()
+			}
+		}
+		fmt.Println(strings.Join(s, "\n")) // TODO locking needed?
+	})
+
+	for _, subCommand := range operation.Commands {
+		testCommand(t, testDir, service, commandPath, subCommand)
 	}
 }


### PR DESCRIPTION
Fixes #47.

This registers the aws_completer fallback recursively for botocore commands, so nested commands such as `aws ec2 wait instance-running --...` get the same missing-flag completion fallback as top-level service operations.

It also updates the AWS integration test to recurse into nested botocore commands and fixes the integration build tag so the expensive aws_completer comparison only runs when explicitly requested.

Validation:
- `go test ./...`
- `SERVICE=ec2 go test -tags integration ./cmd/carapace-aws -run TestService/ec2 -count=1 -timeout 90s`
- `git diff --check`