### PR TITLE
Test nested AWS commands

### DIFF
--- a/cmd/carapace-aws/main_test.go
+++ b/cmd/carapace-aws/main_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/carapace-sh/carapace"
 	"github.com/carapace-sh/carapace-aws/cmd/carapace-aws/cmd/botocore"
 	"github.com/carapace-sh/carapace-bridge/pkg/actions/bridge"
+	specCommand "github.com/carapace-sh/carapace-spec/pkg/command"
 )
 
 func TestService(t *testing.T) {
@@ -77,35 +78,72 @@ func TestService(t *testing.T) {
 				t.Fatal(err.Error())
 			}
 			for _, operation := range command.Commands {
-				t.Run(operation.Name, func(t *testing.T) {
-					t.Parallel()
-					patch := carapace.DiffPatch(
-						bridge.ActionAws("aws"),
-						carapace.Batch(
-							bridge.ActionCarapace("carapace-aws"),
-							// force positional completion for outfile if available (returned by aws completer for streaming operations)
-							bridge.ActionCarapace("carapace-aws").
-								Chdir(testDir).
-								Invoke(carapace.NewContext(service, operation.Name, "")).
-								Retain("outfile").ToA(),
-						).ToA(),
-						carapace.NewContext(service, operation.Name, "--"),
-					)
-
-					s := []string{fmt.Sprintf("\033[2m# %v %v\033[0m", service, operation.Name)}
-					for _, line := range patch {
-						switch {
-						case strings.HasPrefix(line, "-"):
-							s = append(s, fmt.Sprintf("\033[0;31m%v\033[0m", line))
-							t.Fail()
-						case strings.HasPrefix(line, "+"):
-							s = append(s, fmt.Sprintf("\033[0;32m%v\033[0m", line))
-							t.Fail()
-						}
-					}
-					fmt.Println(strings.Join(s, "\n")) // TODO locking needed?
-				})
+				testCommand(t, testDir, service, nil, operation)
 			}
 		})
 	}
+}
+
+func testCommand(t *testing.T, testDir string, service string, parent []string, command specCommand.Command) {
+	path := append(append([]string(nil), parent...), command.Name)
+	if len(command.Commands) > 0 {
+		t.Run(strings.Join(path, " "), func(t *testing.T) {
+			t.Parallel()
+
+			context := append([]string{service}, path...)
+			completionContext := append(append([]string(nil), context...), "")
+
+			patch := carapace.DiffPatch(
+				bridge.ActionAws("aws"),
+				bridge.ActionCarapace("carapace-aws").Chdir(testDir),
+				carapace.NewContext(completionContext...),
+			)
+			assertNoPatch(t, service, path, patch)
+		})
+
+		for _, subCommand := range command.Commands {
+			testCommand(t, testDir, service, path, subCommand)
+		}
+		return
+	}
+
+	t.Run(strings.Join(path, " "), func(t *testing.T) {
+		t.Parallel()
+
+		context := append([]string{service}, path...)
+		invokeContext := append(append([]string(nil), context...), "")
+		patchContext := append(append([]string(nil), context...), "--")
+
+		patch := carapace.DiffPatch(
+			bridge.ActionAws("aws"),
+			carapace.Batch(
+				bridge.ActionCarapace("carapace-aws"),
+				// force positional completion for outfile if available (returned by aws completer for streaming operations)
+				bridge.ActionCarapace("carapace-aws").
+					Chdir(testDir).
+					Invoke(carapace.NewContext(invokeContext...)).
+					Retain("outfile").ToA(),
+			).ToA(),
+			carapace.NewContext(patchContext...),
+		)
+
+		assertNoPatch(t, service, path, patch)
+	})
+}
+
+func assertNoPatch(t *testing.T, service string, path []string, patch []string) {
+	t.Helper()
+
+	s := []string{fmt.Sprintf("\033[2m# %v %v\033[0m", service, strings.Join(path, " "))}
+	for _, line := range patch {
+		switch {
+		case strings.HasPrefix(line, "-"):
+			s = append(s, fmt.Sprintf("\033[0;31m%v\033[0m", line))
+			t.Fail()
+		case strings.HasPrefix(line, "+"):
+			s = append(s, fmt.Sprintf("\033[0;32m%v\033[0m", line))
+			t.Fail()
+		}
+	}
+	fmt.Println(strings.Join(s, "\n")) // TODO locking needed?
 }


### PR DESCRIPTION
Closes #104.\n\nUpdates the service comparison test to recurse through nested command specs and test leaf command paths instead of only top-level operations. This covers custom commands whose actionable operations live deeper than one level.\n\nVerification:\n- GOCACHE=/private/tmp/carapace-go-build GOMODCACHE=/private/tmp/carapace-aws-gomod go test ./cmd/carapace-aws -run '^$'