### PR TITLE
fix: keep create-o-auth2-token command names unchanged

### DIFF
--- a/cmd/carapace-aws/cmd/botocore/aws.signin.yaml
+++ b/cmd/carapace-aws/cmd/botocore/aws.signin.yaml
@@ -2,14 +2,14 @@
 name: signin
 description: AWS Sign-In Service
 commands:
-    - name: create-oauth2-token
+    - name: create-o-auth2-token
       description: CreateOAuth2Token API
       flags:
         --cli-input-json=: Read arguments from the JSON string provided.
         --cli-input-yaml=: Read arguments from the YAML string provided.
         --generate-cli-skeleton: Prints a JSON skeleton to standard output without sending an API request.
         --token-input=!: Flattened token operation inputs The specific operation is determined by grant\_type in the request body
-    - name: create-oauth2-token-with-iam
+    - name: create-o-auth2-token-with-iam
       description: Grants permission to exchange client credentials for an OAuth 2.0 access token scoped to a resource that can be used to access AWS services from applications
       flags:
         --cli-input-json=: Read arguments from the JSON string provided.

--- a/cmd/carapace-spec-botocore/cmd/root.go
+++ b/cmd/carapace-spec-botocore/cmd/root.go
@@ -123,8 +123,6 @@ func CamelCaseToDash(s string) string {
 		"create-cachedi-scsi-volume":                         "create-cached-iscsi-volume",
 		"create-environment-e-c2":                            "create-environment-ec2",
 		"create-storedi-scsi-volume":                         "create-stored-iscsi-volume",
-		"create-o-auth2-token":                               "create-oauth2-token",
-		"create-o-auth2-token-with-iam":                      "create-oauth2-token-with-iam",
 		"create-whats-app-flow":                              "create-whatsapp-flow",
 		"create-whats-app-message-template":                  "create-whatsapp-message-template",
 		"create-whats-app-message-template-from-library":     "create-whatsapp-message-template-from-library",


### PR DESCRIPTION
The AWS CLI uses `create-o-auth2-token` and `create-o-auth2-token-with-iam` (with hyphens), not `create-oauth2-token`. Only `introspect-oauth2-token-with-iam` and `revoke-oauth2-token-with-iam` use the `oauth2` form.

Reverts the incorrect rename introduced in #333.


Assisted-by: Crush:glm-5.2